### PR TITLE
chore: add changelog automation and project metadata

### DIFF
--- a/.versionrc
+++ b/.versionrc
@@ -1,0 +1,18 @@
+{
+  "infile": "CHANGELOG.md",
+  "header": "# Changelog\n\nAll notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org/) for commit guidelines.\n\n<!-- markdownlint-disable -->\n",
+  "skip": { "bump": false, "changelog": false, "commit": true, "tag": true },
+  "types": [
+    { "type": "feat",      "section": "🤿 Enhancements",   "hidden": false },
+    { "type": "perf",      "section": "🚀 Performance",    "hidden": false },
+    { "type": "fix",       "section": "🚧 Fixes",          "hidden": false },
+    { "type": "refactor",  "section": "💻 Refactors",      "hidden": false },
+    { "type": "docs",      "section": "📝 Documentation",  "hidden": false },
+    { "type": "revert",    "section": "♻️ Revert",         "hidden": false },
+    { "type": "build",     "section": "📦 Build",          "hidden": false },
+    { "type": "style",     "section": "🧢 Style",          "hidden": false },
+    { "type": "chore",     "section": "🎪 Chore",          "hidden": false },
+    { "type": "test",      "section": "🎮 Tests",          "hidden": false },
+    { "type": "ci",        "section": "🤖 CI",             "hidden": false }
+  ]
+}

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,4 @@
+{
+  "name": "clang-demo",
+  "version": "0.1.0"
+}


### PR DESCRIPTION
Introduced a `.versionrc` file to automate changelog generation based on conventional commit guidelines, enhancing the documentation process for future releases. Additionally, created a `manifest.json` with initial project details such as name and version, setting the groundwork for project identification and version tracking.