### PR TITLE
ci: enabled daily dependabot updates for github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily
+      timezone: Europe/Warsaw
+      time: "10:00"
+    labels: [deps, ci, workflow]
+
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: daily
+      timezone: Europe/Warsaw
+      time: "11:00"
+    labels: [deps, python, pip]


### PR DESCRIPTION
Introduced a Dependabot configuration to automatically monitor and propose updates for GitHub Actions and Python dependencies on a daily basis. Scheduled updates are set for 10:00 and 11:00 CET, respectively, to ensure consistent dependency management and reduce potential integration issues. Specific labels are assigned to each ecosystem for easy categorization of update PRs.