### PR TITLE
ci: enforce commit message standards with commitlint

### DIFF
--- a/.github/commitlint.config.js
+++ b/.github/commitlint.config.js
@@ -1,0 +1,24 @@
+// Defined rules on commit messages; see the docs: https://commitlint.js.org/#/reference-rules
+
+const TypesArray = ["build", "chore", "ci", "docs", "feat", "fix", "perf", "refactor", "revert", "style", "test"];
+const SubjectsArray = ["upper-case", "pascal-case", "sentence-case", "start-case"];
+
+const Configuration = {
+  rules: {
+    "type-enum": [2, "always", TypesArray],
+    "type-case": [2, "always", "lower-case"],
+    "type-empty": [2, "never"],
+    "scope-case": [2, "always", "kebab-case"],
+    "subject-case": [2, "never", SubjectsArray],
+    "subject-empty": [2, "never"],
+    "subject-full-stop": [2, "never", "."],
+    "header-max-length": [2, "always", 80],
+    "body-case": [2, "always", "sentence-case"],
+    "body-leading-blank": [2, "always"],
+    "body-max-line-length": [2, "always", 100],
+    "footer-leading-blank": [2, "always"],
+    "footer-max-line-length": [2, "always", 100],
+  },
+};
+
+module.exports = Configuration;

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,0 +1,23 @@
+name: Lint Commit Messages
+
+on: [pull_request]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  commitlint:
+    name: Commitlint
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run commitlint
+        uses: wagoid/commitlint-github-action@v5
+        with:
+          configFile: .github/commitlint.config.js


### PR DESCRIPTION
Introduced commitlint configuration file and accompanying GitHub Actions workflow to ensure consistent commit message formatting across the project.

The added rules require specific conventions for types, scope, and subject cases, disallow empty types and subjects, and set maximum length restrictions for various components of the commit message.

The workflow triggers on pull requests to automatically lint incoming commits, maintaining codebase integrity and facilitating clearer project history tracking.