### PR TITLE
style: align codebase with 2-space indentation standard

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,9 +1,9 @@
 ---
 BasedOnStyle: Google
 ColumnLimit: 80
-IndentWidth: 4
+IndentWidth: 2
 ---
 Language: Cpp
 ColumnLimit: 80
-IndentWidth: 4
+IndentWidth: 2
 ---

--- a/.editorconfig
+++ b/.editorconfig
@@ -33,8 +33,8 @@ max_line_length = 80
 insert_final_newline = false
 max_line_length = off
 
-[{CMakeLists.txt,*.{cmake,c,h,cc,hh,cpp,cxx,hpp,hxx}}]
-indent_size = 4
+[{CMakeLists.txt,*.{cmake,c,h,cc,hh,cpp,hpp,cxx,hxx}}]
+indent_size = 2
 max_line_length = 80
 
 [{Makefile,.gitattributes,.gitconfig,.gitcredentials,.gitmessage,.gitmodules}]

--- a/example/mdsanima-awesome/src/main.cpp
+++ b/example/mdsanima-awesome/src/main.cpp
@@ -1,8 +1,10 @@
 // Copyright (c) 2024 MDSANIMA LAB. All rights reserved.
 // Licensed under the MIT license.
 
+// Example C++ implementation of the MDSANIMA LAB project.
+
 #include <iostream>
 
 int main() {
-    std::cout << "This is example of MDSANIMA AWESOME project!" << std::endl;
+  std::cout << "This is the MDSANIMA AWESOME project." << std::endl;
 }

--- a/example/mdsanima-cprogram/src/main.c
+++ b/example/mdsanima-cprogram/src/main.c
@@ -1,10 +1,12 @@
 // Copyright (c) 2024 MDSANIMA LAB. All rights reserved.
 // Licensed under the MIT license.
 
+// Example C implementation of the MDSANIMA LAB project.
+
 #include <stdio.h>
 
 int main(void) {
-    printf("This is example code of MDSANIMA C Program!\n");
+  printf("This is the MDSANIMA C Program!\n");
 
-    return 0;
+  return 0;
 }


### PR DESCRIPTION
Standardized indentation across the codebase to 2 spaces for better consistency and alignment with common style practices. This change affects `.clang-format` and `.editorconfig` settings as well as **C** and **C++** example projects.

Additionally, refined project description comments and streamlined example code output for clarity.