### PR TITLE
style: refine commentary across multiple projects

### DIFF
--- a/example/mdsanima-awesome/main.c
+++ b/example/mdsanima-awesome/main.c
@@ -1,7 +1,7 @@
 // Copyright (c) 2024 MDSANIMA LAB. All rights reserved.
 // Licensed under the MIT license.
 
-// Example C implementation of the example MDSANIMA AWESOME project.
+// Example C implementation of the MDSANIMA AWESOME project.
 
 #include <stdio.h>
 

--- a/example/mdsanima-fantastic/main.cc
+++ b/example/mdsanima-fantastic/main.cc
@@ -1,7 +1,7 @@
 // Copyright (c) 2024 MDSANIMA LAB. All rights reserved.
 // Licensed under the MIT license.
 
-// Example C++ implementation of the example MDSANIMA FANTASTIC project.
+// Example C++ implementation of the MDSANIMA FANTASTIC project.
 
 #include <iostream>
 

--- a/example/mdsanima-incredible/main.cpp
+++ b/example/mdsanima-incredible/main.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) 2024 MDSANIMA LAB. All rights reserved.
 // Licensed under the MIT license.
 
-// Example C++ implementation of the example MDSANIMA INCREDIBLE project.
+// Example C++ implementation of the MDSANIMA INCREDIBLE project.
 
 #include <iostream>
 

--- a/example/mdsanima-stunning/main.cxx
+++ b/example/mdsanima-stunning/main.cxx
@@ -1,7 +1,7 @@
 // Copyright (c) 2024 MDSANIMA LAB. All rights reserved.
 // Licensed under the MIT license.
 
-// Example C++ implementation of the example MDSANIMA STUNNING project.
+// Example C++ implementation of the MDSANIMA STUNNING project.
 
 #include <iostream>
 


### PR DESCRIPTION
Removed redundant _example_ word from the introductory comments in main source files of various projects to clarify the descriptions and make them more concise. The language is streamlined without altering the meaning or scope.