### PR TITLE
feat: introduce clang-tidy checks

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,9 +1,6 @@
----
+Language: Cpp
+
 BasedOnStyle: Google
 ColumnLimit: 80
 IndentWidth: 2
----
-Language: Cpp
-ColumnLimit: 80
-IndentWidth: 2
----
+SpacesBeforeTrailingComments: 2

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,27 @@
+Checks: "-*,
+  modernize-*,
+  readability-*,
+  performance-*,
+  bugprone-*"
+
+CheckOptions:
+  - key: readability-identifier-naming.ClassCase
+    value: CamelCase
+  - key: readability-identifier-naming.EnumCase
+    value: CamelCase
+  - key: readability-identifier-naming.FunctionCase
+    value: camelBack
+  - key: readability-identifier-naming.GlobalConstantCase
+    value: UPPER_CASE
+  - key: readability-identifier-naming.GlobalVariableCase
+    value: UPPER_CASE
+  - key: readability-identifier-naming.MemberCase
+    value: camelBack
+  - key: readability-identifier-naming.StructCase
+    value: camelBack
+  - key: readability-identifier-naming.UnionCase
+    value: CamelCase
+  - key: readability-identifier-naming.VariableCase
+    value: camelBack
+
+WarningsAsErrors: "*"

--- a/.editorconfig
+++ b/.editorconfig
@@ -33,6 +33,9 @@ max_line_length = 80
 insert_final_newline = false
 max_line_length = off
 
+[{.clang-format,.clang-tidy}]
+indent_size = 2
+
 [{CMakeLists.txt,*.{cmake,c,h,cc,hh,cpp,hpp,cxx,hxx}}]
 indent_size = 2
 max_line_length = 80


### PR DESCRIPTION
Standardize code style by aligning the `.clang-format` file with Google's style guide and setting a 2-space indent for specific configuration files. Introduced a `.clang-tidy` file to enforce modern code practices and readability, including naming conventions and treating warnings as errors to maintain code quality.

Also refactored some code. Harmonize indent size across `.clang-format`, `.clang-tidy`, and `.editorconfig`. Enforce 2 spaces before trailing comments in `.clang-format`. Add readability and performance checks in the new `.clang-tidy` configuration.

These changes ensure consistent code style and raise standard across the codebase. Potential issues should now be caught earlier, resulting in a more robust and maintainable code.

## Explained by AI

The changes pertain to the introduction of `clang-tidy` checks to improve the codebase's quality. `clang-tidy` is a tool that analyzes C++ code to ensure adherence to coding standards and to identify potential bugs.

Here's a breakdown of the changes made:

1. **.clang-format file changes**:
   - The file has been restructured for better readability. However, the actual settings (`BasedOnStyle: Google`, `ColumnLimit: 80`, and `IndentWidth: 2`) have been preserved. The addition `SpacesBeforeTrailingComments: 2` ensures that there are two spaces before trailing comments, contributing to a more uniform and readable coding style. This aligns with formatting practices to increase readability but does not change code logic.

2. **.clang-tidy file created**:
   - A new configuration file for `clang-tidy` has been added. This defines a suite of checks that will be enforced, including modernization checks (`modernize-*`), readability improvements (`readability-*`), performance issues (`performance-*`), and common mistakes that can be bug-prone (`bugprone-*`). The file also defines `CheckOptions` that establish naming conventions for various identifiers such as classes, enums, functions, variables, etc., using CamelCase or camelBack as appropriate. These conventions ensure a standardized code format across the codebase.
   - The `WarningsAsErrors: "*"` option at the end signals that all warnings should be treated as errors, which enforces strict compliance by not allowing the code to compile until all warnings are addressed. This setting promotes a higher code quality standard.

3. **.editorconfig file changes**:
   - The addition to the `.editorconfig` file applies an `indent_size` of 2 specifically to the recently added `.clang-format and .clang-tidy` files, ensuring that these configuration files adhere to the same indentation conventions as the rest of the codebase.

In summary, these changes indicate a significant step towards ensuring code quality and consistency. By leveraging the `clang-tidy` tool and adhering to its checks, along with maintaining consistent formatting rules, the codebase will benefit from improved readability, adherence to modern C++ standards, and potentially fewer bugs due to enforced static analysis checks. For reviewers, these changes signal a commitment to upholding best practices in the codebase's future development.