### PR TITLE
chore: initialized placeholder dirs for project structure

### DIFF
--- a/project/mdsanima-blizzard/.gitkeep
+++ b/project/mdsanima-blizzard/.gitkeep
@@ -1,0 +1,1 @@
+<!-- Keep this directory -->

--- a/project/mdsanima-celestial/.gitkeep
+++ b/project/mdsanima-celestial/.gitkeep
@@ -1,0 +1,1 @@
+<!-- Keep this directory -->

--- a/project/mdsanima-deeply/.gitkeep
+++ b/project/mdsanima-deeply/.gitkeep
@@ -1,0 +1,1 @@
+<!-- Keep this directory -->

--- a/project/mdsanima-ember/.gitkeep
+++ b/project/mdsanima-ember/.gitkeep
@@ -1,0 +1,1 @@
+<!-- Keep this directory -->

--- a/project/mdsanima-firelooy/.gitkeep
+++ b/project/mdsanima-firelooy/.gitkeep
@@ -1,0 +1,1 @@
+<!-- Keep this directory -->


### PR DESCRIPTION
Added `.gitkeep` files to preserve the structure of five new directories within the `project` folder. This ensures they are included in version control, even though they are currently empty.

Maintaining the intended project structure from the outset facilitates better organization and future development work.