### PR TITLE
refactor: use shared library in fantastic example

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,8 +9,11 @@ set(CMAKE_CXX_EXTENSIONS        OFF)
 
 project(mdsanima VERSION 0.2.1)
 
-# Example demo programs
+# Example demo program
 add_executable(${PROJECT_NAME}-fantastic example/mdsanima-fantastic/main.cc)
+add_library(fantastic SHARED example/mdsanima-fantastic/lib.cc)
+target_link_libraries(${PROJECT_NAME}-fantastic fantastic)
+
 add_executable(${PROJECT_NAME}-incredible example/mdsanima-incredible/main.cpp)
 add_executable(${PROJECT_NAME}-stunning example/mdsanima-stunning/main.cxx)
 

--- a/example/mdsanima-fantastic/lib.cc
+++ b/example/mdsanima-fantastic/lib.cc
@@ -1,0 +1,10 @@
+// Copyright (c) 2024 MDSANIMA LAB. All rights reserved.
+// Licensed under the MIT license.
+
+// Simple C++ example demo of `FANTASTIC` shared library implementation.
+
+#include "lib.hh"
+
+#include <iostream>
+
+void mprint(const char* text) { std::cout << text << '\n'; }

--- a/example/mdsanima-fantastic/lib.hh
+++ b/example/mdsanima-fantastic/lib.hh
@@ -1,0 +1,13 @@
+// Copyright (c) 2024 MDSANIMA LAB. All rights reserved.
+// Licensed under the MIT license.
+
+// Simple C++ example demo of `FANTASTIC` shared library header file.
+
+#pragma once
+
+/**
+ * Simple text message printing implementation for the demo purpose only.
+ *
+ * @param text The text message to print in the terminal.
+ */
+void mprint(const char* text);

--- a/example/mdsanima-fantastic/main.cc
+++ b/example/mdsanima-fantastic/main.cc
@@ -1,8 +1,11 @@
 // Copyright (c) 2024 MDSANIMA LAB. All rights reserved.
 // Licensed under the MIT license.
 
-// Simple C++ implementation of the example `MDSANIMA FANTASTIC` demo project.
+// The main program of `MDSANIMA FANTASTIC` example demo project.
 
-#include <iostream>
+#include "lib.hh"
 
-auto main() -> int { std::cout << "Hello World from the MDSANIMA FANTASTIC" << '\n'; }
+auto main() -> int {
+    const char* message = "Hello World from the MDSANIMA FANTASTIC";
+    mprint(message);
+}


### PR DESCRIPTION
Moved the printing logic from the main executable to a new shared library in the fantastic example, streamlining the `main.cc` file. This change encourages modularity and demonstrates shared library usage in the project. By extracting logic into `lib.cc` and including it as a dynamic library, we set a precedent for future development practices and improved the project structure for easier maintenance and enhancement.

- Introduced `fantastic` as a shared library.
- Updated `main.cc` to utilize the new library for printing messages.
- Added `lib.cc` and `lib.hh` to implement the message printing functionality in a separate module.

This modification not only makes the code more organized but also provides a practical example of how to create and link shared libraries within a CMake project