### PR TITLE
chore: update `.gitignore` to exclude todo files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -451,5 +451,8 @@ temp
 .tmp
 .temp
 
+# Temporary files case sensitive todo markdown
+*[Tt][Oo][Dd][Oo].md
+
 # Extension sqltools connections secrets
 .vscode*


### PR DESCRIPTION
Enhanced `.gitignore` to filter out case-sensitive variations of TODO markdown files. This ensures that personal or temporary task lists don't clutter the repository, maintaining a clean project space.