### PR TITLE
feat: add markdownlint configuration

### DIFF
--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -1,0 +1,37 @@
+# Maintain consistent coding style across the entire project.
+
+# This is a configuration file for markdownlint.
+
+# Default state for all rules.
+default: true
+
+# Line length.
+MD013: true
+
+# Trailing heading.
+MD026:
+  punctuation: .,;:!。，；：！
+
+# Multiple spaces blockquote.
+MD027: true
+
+# Inline HTML.
+MD033: false
+
+# Emphasis heading.
+MD036:
+  punctuation: .,;:!?。，；：！？
+
+# Link fragments.
+MD051: false
+
+# Max line length.
+line-length:
+  line_length: 100
+  heading_line_length: 100
+  code_block_line_length: 100
+  code_blocks: true
+  tables: true
+  headings: true
+  strict: true
+  stern: true

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,27 @@
+{
+  "endOfLine": "lf",
+  "printWidth": 100,
+  "semi": true,
+  "singleQuote": false,
+  "tabWidth": 2,
+  "trailingComma": "es5",
+  "overrides": [
+    {
+      "files": "*.md",
+      "excludeFiles": "CHANGELOG.md",
+      "options": {
+        "parser": "markdown",
+        "arrowParens": "always",
+        "bracketSpacing": true,
+        "endOfLine": "lf",
+        "printWidth": 100,
+        "proseWrap": "always",
+        "semi": false,
+        "singleQuote": false,
+        "tabWidth": 2,
+        "trailingComma": "none",
+        "useTabs": false
+      }
+    }
+  ]
+}

--- a/.versionrc
+++ b/.versionrc
@@ -1,6 +1,6 @@
 {
   "infile": "CHANGELOG.md",
-  "header": "# Changelog\n\nAll notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org/) for commit guidelines.\n\n<!-- markdownlint-disable -->\n",
+  "header": "# Changelog\n\n<!-- markdownlint-disable -->\n\nAll notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org/) for commit guidelines.\n",
   "skip": { "bump": false, "changelog": false, "commit": true, "tag": true },
   "bumpFiles": [
     { "type": "json",      "filename": "manifest.json"                     }


### PR DESCRIPTION
Added `.markdownlint.yml` and `.prettierrc` configuration files to establish and maintain uniform coding and Markdown styling conventions across the project.

These configurations enforce rules such as consistent line lengths, the use of semi-colons, and the handling of inline HTML and link fragments in Markdown, ensuring readable and maintainable documentation and codebase. Moreover, revised the `CHANGELOG.md` section header in `.versionrc` for better clarity and readability, aligning with markdownlint's recommendations.

This initiative aims to minimize style discrepancies and improve code readability, facilitating a smoother collaboration process. It is an essential step towards a more structured and efficient development workflow, acknowledging that consistency is key to a project's long-term success.