### PR TITLE
refactor: rename 'amarok' demo to 'amarooke'

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ add_library(stunning SHARED example/mdsanima-stunning/lib.cxx)
 target_link_libraries(${PROJECT_NAME}-stunning stunning)
 
 # Project demo programs
-add_executable(${PROJECT_NAME}-amarok project/mdsanima-amarok/main.c)
+add_executable(${PROJECT_NAME}-amarooke project/mdsanima-amarooke/main.c)
 add_executable(${PROJECT_NAME}-blizzard project/mdsanima-blizzard/main.c)
 add_executable(${PROJECT_NAME}-conquest project/mdsanima-conquest/main.c)
 
@@ -33,17 +33,17 @@ add_executable(${PROJECT_NAME}-conquest project/mdsanima-conquest/main.c)
 add_library(${PROJECT_NAME} STATIC lib/mdsanima.c)
 
 # Targeting demo library
-target_link_libraries(mdsanima-amarok mdsanima)
+target_link_libraries(mdsanima-amarooke mdsanima)
 target_link_libraries(mdsanima-blizzard mdsanima)
 target_link_libraries(mdsanima-conquest mdsanima)
 
 # Targeting demo programs
-target_include_directories(mdsanima INTERFACE project/mdsanima-amarok/)
+target_include_directories(mdsanima INTERFACE project/mdsanima-amarooke/)
 target_include_directories(mdsanima INTERFACE project/mdsanima-blizzard/)
 target_include_directories(mdsanima INTERFACE project/mdsanima-conquest/)
 
 # Installing demo programs
-install(TARGETS mdsanima-amarok DESTINATION bin)
+install(TARGETS mdsanima-amarooke DESTINATION bin)
 install(TARGETS mdsanima-blizzard DESTINATION bin)
 install(TARGETS mdsanima-conquest DESTINATION bin)
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Introduction to [CMake](https://cmake.org/) configuration for building and runni
 **C/C++** programs.
 
 > [!NOTE]
+>
 > To build the sample _demo_ programs that are in the _example_ and _project_ directory, we are
 > using `cmake` build system command on **WSL** or another virtual machine with a **GNU/Linux**
 > system, such as **Debian**, **Ubuntu**, **Fedora**, **CentOS**, and so on. The choice is yours.
@@ -38,6 +39,7 @@ make
 ```
 
 > [!CAUTION]
+>
 > For the build to succeed, you must copy the header file `mdsanima.h` into the `/usr/local/include`
 > directory. This is because the `mdsanima.h` header file is a part of the **MDSANIMA** library,
 > which is not a part of the **CMake** build system right now. To copy this file to the destination
@@ -47,7 +49,7 @@ make
 You can now run the demo programs by typing the following command inside the `build` directory:
 
 ```shell
-./mdsanima-amarok
+./mdsanima-amarooke
 ./mdsanima-blizzard
 ./mdsanima-conquest
 ./mdsanima-fantastic
@@ -65,7 +67,7 @@ the `build` directory. After running the first command `cmake -B build` to gener
 for the _example_ and _project_ programs, and then running the `make` command to build the
 executable files, you can run the _example_ programs that we showed above.
 
-The _mdsanima-amarok_, _mdsanima-blizzard_ and _mdsanima-conquest_ program is quite different. You
+The _mdsanima-amarooke_, _mdsanima-blizzard_ and _mdsanima-conquest_ program is quite different. You
 can install the project program by typing the following command:
 
 ```shell
@@ -73,12 +75,12 @@ cd build
 sudo make install
 ```
 
-That command will install the _mdsanima-amarok_, _mdsanima-blizzard_ and _mdsanima-conquest_ project
-demo programs in the `/usr/local/bin` directory, and you can run the program by typing the following
-command:
+That command will install the _mdsanima-amarooke_, _mdsanima-blizzard_ and _mdsanima-conquest_
+project demo programs in the `/usr/local/bin` directory, and you can run the program by typing the
+following command:
 
 ```shell
-mdsanima-amarok
+mdsanima-amarooke
 mdsanima-blizzard
 mdsanima-conquest
 ```
@@ -97,6 +99,7 @@ are located in the `src` directory, but you can also put all the files in one di
 depends on the project.
 
 > [!NOTE]
+>
 > To manualy build the demo programs, you can use the `gcc` or `g++` command to compile and link the
 > source code files.
 
@@ -112,19 +115,20 @@ g++ -o build/mdsanima-fantastic main.cc
 This method is only recommended if you want to manually build the program.
 
 > [!IMPORTANT]
+>
 > The sample projects are written in **C** and **C++** languages, and the source code files have
 > extensions `.c`, `.cc`, and `.cpp`. You can also use the `.cxx` file format, as we added in the
-> example project. Here is just an example. Remember to use the chosen format and be consistent
-> with it.
+> example project. Here is just an example. Remember to use the chosen format and be consistent with
+> it.
 
 All projects are the same; they only differ in the text displayed in the terminal and in other file
 extensions.
 
 ## Google Style Guide
 
-Also, check how _Google_ does it.
-Here is a [C++ Style Guide](https://google.github.io/styleguide/cppguide.html)
-and [Objective-C Style Guide](https://google.github.io/styleguide/objcguide.html) provided by the
+Also, check how _Google_ does it. Here is a
+[C++ Style Guide](https://google.github.io/styleguide/cppguide.html) and
+[Objective-C Style Guide](https://google.github.io/styleguide/objcguide.html) provided by the
 [Google Style Guide](https://github.com/google/styleguide). The complete guide for naming
 conventions, variables, functions, and more by _Google_.
 

--- a/project/mdsanima-amarooke/main.c
+++ b/project/mdsanima-amarooke/main.c
@@ -1,13 +1,13 @@
 // Copyright (c) 2024 MDSANIMA LAB. All rights reserved.
 // Licensed under the MIT license.
 
-// The main C demo program for the `MDSANIMA AMAROK` project.
+// The main C demo program for the `MDSANIMA AMAROOKE` project.
 
 #include <mdsanima.h>
 
 int main(void)
 {
-    const char *message = " MDSANIMA AMAROK ";
+    const char *message = " MDSANIMA AMAROOKE ";
     const int orange    = 202;  // Text color
     const int red       = 196;  // Background color
 


### PR DESCRIPTION
This commit updates the project to rename the 'amarok' demo program to 'amarooke', extending across CMake configurations, documentation, and source files. It includes adjustments in the CMakeLists.txt for executable generation, linking, and installation paths; updates to README.md to ensure the documentation reflects the new demo program name; and a source file rename with corresponding string updates to match the new naming convention. This change aligns with a decision to standardize demo program names more closely with their thematic representation, enhancing clarity and project cohesion.