### PR TITLE
style(clang-format): enable trailing comment aligments

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -31,6 +31,11 @@ AlignConsecutiveDeclarations: false
 # Align escaped newlines for the left.
 AlignEscapedNewlinesLeft: true
 
+# Align trailing comments.
+# const int foo;      // Comment foo
+# const int bar = 2;  // Comment bar
+AlignTrailingComments: true
+
 # Don't allow this rule.
 AllowShortFunctionsOnASingleLine: false
 


### PR DESCRIPTION
Enabled alignment of trailing comments in the `.clang-format` configuration to improve code readability and maintain consistency across all code comments. This ensures that comments at the end of lines align neatly, making the code easier to read and understand at a glance.