### PR TITLE
fix: background color first in lib

### DIFF
--- a/lib/mdsanima.c
+++ b/lib/mdsanima.c
@@ -6,7 +6,7 @@
 #include <mdsanima.h>
 #include <stdio.h>
 
-void cprint(const char *text, int foreground, int background)
+void cprint(const char *text, int background, int foreground)
 {
-    printf("\e[38;5;%dm\e[48;5;%dm\e[1m%s\e[0m\n", foreground, background, text);
+    printf("\e[48;5;%dm\e[38;5;%dm\e[1m%s\e[0m\n", background, foreground, text);
 }

--- a/lib/mdsanima.h
+++ b/lib/mdsanima.h
@@ -12,9 +12,9 @@
  * @note Wrapper for the ANSI escape sequence, where 0 is black and 255 is white.
  *
  * @param text The bold text message to stdout print in the color on the terminal.
- * @param foreground The foreground color of the text message.  A number from 0 to 255.
  * @param background The background color of the text message.  A number from 0 to 255.
+ * @param foreground The foreground color of the text message.  A number from 0 to 255.
  */
-void cprint(const char *text, int foreground, int background);
+void cprint(const char *text, int background, int foreground);
 
 #endif

--- a/project/mdsanima-amarooke/main.c
+++ b/project/mdsanima-amarooke/main.c
@@ -8,10 +8,10 @@
 int main(void)
 {
     const char *message = " MDSANIMA AMAROOKE ";
-    const int   fgColor = 38;  // Text color
     const int   bgColor = 26;  // Background color
+    const int   fgColor = 38;  // Text color
 
-    cprint(message, fgColor, bgColor);
+    cprint(message, bgColor, fgColor);
 
     return 0;
 }

--- a/project/mdsanima-blizzard/main.c
+++ b/project/mdsanima-blizzard/main.c
@@ -8,10 +8,10 @@
 int main(void)
 {
     const char *message = " MDSANIMA BLIZZARD ";
-    const int   fgColor = 48;  // Text color
     const int   bgColor = 36;  // Background color
+    const int   fgColor = 48;  // Text color
 
-    cprint(message, fgColor, bgColor);
+    cprint(message, bgColor, fgColor);
 
     return 0;
 }

--- a/project/mdsanima-conquest/main.c
+++ b/project/mdsanima-conquest/main.c
@@ -8,10 +8,10 @@
 int main(void)
 {
     const char *message = " MDSANIMA CONQUEST ";
-    const int   fgColor = 74;  // Text color
     const int   bgColor = 62;  // Background color
+    const int   fgColor = 74;  // Text color
 
-    cprint(message, fgColor, bgColor);
+    cprint(message, bgColor, fgColor);
 
     return 0;
 }


### PR DESCRIPTION
This change is for swapping color in function on library.

The background color in `cprint` function is first and then the foreground color. I think is more intuitive.